### PR TITLE
egdl-1429: update plugin versions + fix checkstyle bug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: build
+on: [push, pull_request]
+jobs:
+  test:
+    name: Package and run all tests
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Run Maven Targets
+      run: mvn package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.0] - TBD
+### Changed
+- Updated `javadoc.plugin` version from 3.0.1 to 3.2.0.
+- Updated `release.plugin` from 2.5.3 to 3.0.0-M1.
+- Updated `source.plugin` from 3.0.1 to 3.2.0.
+
 ## [1.1.0] - 2019-08-08
 ### Added
 - Spotbugs exclude filter file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated `javadoc.plugin` version from 3.0.1 to 3.2.0.
 - Updated `release.plugin` from 2.5.3 to 3.0.0-M1.
 - Updated `source.plugin` from 3.0.1 to 3.2.0.
+- Changed location of *LineLength* to solve a bug that appeared in the updated version of the checkstyle plugin.
 
 ## [1.1.0] - 2019-08-08
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.expediagroup</groupId>
   <artifactId>eg-oss-plugin-config</artifactId>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <description>Configuration files needed by various plugins (e.g. Checkstyle, Mycila, etc.)</description>
   <url>https://github.com/ExpediaGroup/eg-oss-plugin-config</url>
   <inceptionYear>2019</inceptionYear>
@@ -38,9 +38,9 @@
 
   <properties>
     <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
-    <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
-    <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
-    <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
+    <maven.javadoc.plugin.version>3.2.0</maven.javadoc.plugin.version>
+    <maven.release.plugin.version>3.0.0-M1</maven.release.plugin.version>
+    <maven.source.plugin.version>3.2.0</maven.source.plugin.version>
     <nexus.staging.maven.plugin.version>1.6.8</nexus.staging.maven.plugin.version>
   </properties>
 

--- a/src/main/resources/checkstyle/eg-checkstyle.xml
+++ b/src/main/resources/checkstyle/eg-checkstyle.xml
@@ -3,6 +3,10 @@
   "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 
 <module name="Checker">
+
+  <module name="LineLength">
+    <property name="max" value="140" />
+  </module>
   <property name="severity" value="warning"/>
   <!-- Checks that property files contain the same keys.         -->
   <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->
@@ -48,9 +52,7 @@
 
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->
-    <module name="LineLength">
-      <property name="max" value="140" />
-    </module>
+
     <module name="MethodLength" />
     <module name="ParameterNumber" >
       <property name="max" value="5"/>


### PR DESCRIPTION
- **updated the plugin versions**
- **fixed a bug** that appears when you update the version of the checkstyle plugin; you have to change the location of _LineLength_ so that its parent is not _TreeWalker._